### PR TITLE
Feature/publish mvn central

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,28 +123,24 @@ The following tables shows some more examples how the result could be.
 
 ## Publication
 
-### ... to a Maven repo
+This module is deployed and published to Maven Central. All JAR files are signed via Gradle signing plugin. 
 
-_Publishing to local repo_
-```shell
-gradle publishToMavenLocal
-```
+The following properties have to be set via command line or ``~/.gradle/gradle.properties``
 
-_Publishing to remote repo_
-```shell
-gradle publish -DdeployUrl=<repo-url> -DdeployUsername=<repo-user> -DdeployPassword=<repo-password>
-```
+| Property                      | Description                                         |
+| ----------------------------- | --------------------------------------------------- |
+| `moduleVersion`               | Version of deployed module, default is `1-SNAPSHOT` |
+| `deployUrl`                   | Maven repository URL                                |
+| `deployUsername`              | Maven repository username                           |
+| `deployPassword`              | Maven repository password                           |
+| `signing.keyId`               | GPG private key ID (short form)                     |
+| `signing.password`            | GPG private key password                            |
+| `signing.secretKeyRingFile`   | Path to GPG private key                             |
 
-_Set a custom version_
-```shell
-gradle publish -DmoduleVersion=<version>
-```
-### ... to GitHub Packages
-
-Some hints for using GitHub Packages as Maven repository
-
-* Deploy URL is https://maven.pkg.github.com/OWNER/REPOSITRY
-* As password generate an access token and grant permissions to ``write:packages`` (Settings -> Developer settings -> Personal access token)
+If all properties are set, call the following to build, deploy and release Testerra:
+````shell
+gradle publish closeAndReleaseRepository
+````
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Testerra TeamCity Connector
 
 <p align="center">
-    <a href="https://mvnrepository.com/artifact/io.testerra" title="MavenCentral"><img src="https://img.shields.io/maven-central/v/io.testerra/teamcity-connector?label=Maven%20Central"></a>
+    <a href="https://mvnrepository.com/artifact/io.testerra/teamcity-connector" title="MavenCentral"><img src="https://img.shields.io/maven-central/v/io.testerra/teamcity-connector?label=Maven%20Central"></a>
     <a href="/../../commits/" title="Last Commit"><img src="https://img.shields.io/github/last-commit/telekom/testerra-teamcity-connector?style=flat"></a>
     <a href="/../../issues" title="Open Issues"><img src="https://img.shields.io/github/issues/telekom/testerra-teamcity-connector?style=flat"></a>
     <a href="./LICENSE" title="License"><img src="https://img.shields.io/badge/License-Apache%202.0-green.svg?style=flat"></a>
@@ -30,7 +30,7 @@ It will register automatically by using the Testerra ModuleHook.
 
 ### Requirements
 
-![Maven Central with version prefix filter](https://img.shields.io/maven-central/v/io.testerra/core/1.0-RC-32?label=Testerra)
+![Maven Central](https://img.shields.io/maven-central/v/io.testerra/core/1.0-RC-32?label=Testerra)
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The following properties have to be set via command line or ``~/.gradle/gradle.p
 | `signing.password`            | GPG private key password                            |
 | `signing.secretKeyRingFile`   | Path to GPG private key                             |
 
-If all properties are set, call the following to build, deploy and release Testerra:
+If all properties are set, call the following to build, deploy and release this module:
 ````shell
 gradle publish closeAndReleaseRepository
 ````

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Testerra TeamCity Connector
 
 <p align="center">
+    <a href="https://mvnrepository.com/artifact/io.testerra" title="MavenCentral"><img src="https://img.shields.io/maven-central/v/io.testerra/teamcity-connector?label=Maven%20Central"></a>
     <a href="/../../commits/" title="Last Commit"><img src="https://img.shields.io/github/last-commit/telekom/testerra-teamcity-connector?style=flat"></a>
     <a href="/../../issues" title="Open Issues"><img src="https://img.shields.io/github/issues/telekom/testerra-teamcity-connector?style=flat"></a>
     <a href="./LICENSE" title="License"><img src="https://img.shields.io/badge/License-Apache%202.0-green.svg?style=flat"></a>
@@ -29,7 +30,7 @@ It will register automatically by using the Testerra ModuleHook.
 
 ### Requirements
 
-* Testerra in Version: `1.0-RC-29`
+![Maven Central with version prefix filter](https://img.shields.io/maven-central/v/io.testerra/core/1.0-RC-32?label=Testerra)
 
 ### Usage
 
@@ -38,7 +39,7 @@ Include the following dependency in your project.
 Gradle:
 
 ````groovy
-implementation 'io.testerra:teamcity-connector:1.0-RC-4'
+implementation 'io.testerra:teamcity-connector:1.0'
 ````
 
 Maven:
@@ -48,7 +49,7 @@ Maven:
 <dependency>
     <groupId>io.testerra</groupId>
     <artifactId>teamcity-connector</artifactId>
-    <version>1.0-RC-4</version>
+    <version>1.0</version>
 </dependency>
 ````
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Include the following dependency in your project.
 Gradle:
 
 ````groovy
-implementation 'eu.tsystems.mms.tic.testerra:teamcity-connector:1.0-RC-4'
+implementation 'io.testerra:teamcity-connector:1.0-RC-4'
 ````
 
 Maven:
@@ -46,7 +46,7 @@ Maven:
 ````xml
 
 <dependency>
-    <groupId>eu.tsystems.mms.tic.testerra</groupId>
+    <groupId>io.testerra</groupId>
     <artifactId>teamcity-connector</artifactId>
     <version>1.0-RC-4</version>
 </dependency>

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ ext {
         moduleVersion = System.getProperty('moduleVersion')
     }
 
-    group 'eu.tsystems.mms.tic.testerra'
+    group 'io.testerra'
     version moduleVersion
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,16 @@
+plugins {
+    id "io.codearte.nexus-staging" version "0.30.0"
+}
+
 apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
+apply plugin: 'io.codearte.nexus-staging'
 
 ext {
     // Minimum required Testerra version
-    testerraCompileVersion = '1.0-RC-10'
+    testerraCompileVersion = '1.0-RC-32'
     // Unit tests use the latest Testerra version
     testerraTestVersion = '[1.0-RC,2-SNAPSHOT)'
     moduleVersion = '1-SNAPSHOT'
@@ -21,9 +26,9 @@ ext {
 apply from: rootProject.file('publish.gradle')
 
 dependencies {
-    compileOnly 'eu.tsystems.mms.tic.testerra:driver-ui-desktop:' + testerraCompileVersion
+    compileOnly 'io.testerra:driver-ui-desktop:' + testerraCompileVersion
 
-    testImplementation 'eu.tsystems.mms.tic.testerra:driver-ui-desktop:' + testerraTestVersion
+    testImplementation 'io.testerra:driver-ui-desktop:' + testerraTestVersion
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'maven-publish'
+apply plugin: 'signing'
 
 ext {
     // Minimum required Testerra version

--- a/publish.gradle
+++ b/publish.gradle
@@ -100,13 +100,5 @@ allprojects {
             sign publishing.publications.mavenJava
         }
 
-        uploadArchives {
-            repositories {
-                mavenDeployer {
-                    beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-                }
-            }
-
-        }
     }
 }

--- a/publish.gradle
+++ b/publish.gradle
@@ -4,15 +4,15 @@
 
 // Maven basis attributes
 ext {
-  libraryName = 'Testerra'
+  libraryName = 'Testerra TeamCity Connector'
   artifact = project.getName().toLowerCase()
   packagingType = 'jar'
 
   libraryDescription = "Testerra ${project.getName()} module"
 
   siteUrl = 'https://testerra.io'
-  gitUrl = 'https://github.com/telekom/testerra-selenoid-connector.git'
-  issueUrl = 'https://github.com/telekom/testerra-selenoid-connector/issues'
+  gitUrl = 'https://github.com/telekom/testerra-teamcity-connector.git'
+  issueUrl = 'https://github.com/telekom/testerra-teamcity-connector/issues'
 
   developerId = 'MMS'
   developerName = 'Testerra Team T-Systems MMS'

--- a/publish.gradle
+++ b/publish.gradle
@@ -71,13 +71,20 @@ allprojects {
       from sourceSets.main.allSource
     }
 
+    task javadocJar(type: Jar) {
+      archiveClassifier.set('javadoc')
+      from javadoc
+    }
+
     artifacts {
       archives sourcesJar
+      archives javadocJar
     }
 
     publications {
       mavenJava(MavenPublication) {
         from components.java
+        artifact javadocJar
         artifact sourcesJar
       }
     }

--- a/publish.gradle
+++ b/publish.gradle
@@ -5,14 +5,11 @@
 // Maven pom.xml attributes
 ext {
     libraryName = 'Testerra TeamCity Connector'
-    artifact = project.getName().toLowerCase()
     packagingType = 'jar'
-
-    libraryDescription = "Testerra ${project.getName()} module"
 
     siteUrl = 'https://testerra.io'
     gitUrl = 'scm:git:git://github.com/telekom/testerra-teamcity-connector.git'
-    issueUrl = 'https://github.com/telekom/testerra-teamcity-connector/issues'
+    gitHttpsUrl = 'https://github.com/telekom/testerra-teamcity-connector/'
 
     developerId = 'MMS'
     developerName = 'Testerra Team T-Systems MMS'
@@ -25,24 +22,44 @@ ext {
     allLicenses = ["Apache-2.0"]
 }
 
+nexusStaging {
+    serverUrl = "https://s01.oss.sonatype.org/service/local/"
+    packageGroup = "io.testerra"
+    username = System.getProperty("deployUsername")
+    password = System.getProperty("deployPassword")
+}
+
 allprojects {
 
+    def libraryDescription = "Testerra test automation framework - ${project.getName()} module"
+
+    javadoc {
+        // Support JDK 8 annotations
+        options.tags = [
+                "implNote:a:Implementation Note:",
+                "apiNote:a:API Note:",
+                "implSpec:a:Implementation Requirements:"
+        ]
+        // Prevent errors during generation
+        options.addStringOption('Xdoclint:none', '-quiet')
+    }
+
+    task sourcesJar(type: Jar, dependsOn: classes) {
+        archiveClassifier.set('sources')
+        from sourceSets.main.allSource
+    }
+
+    task javadocJar(type: Jar) {
+        archiveClassifier.set('javadoc')
+        from javadoc
+    }
+
+    artifacts {
+        archives sourcesJar
+        archives javadocJar
+    }
+
     publishing {
-
-        task sourcesJar(type: Jar, dependsOn: classes) {
-            archiveClassifier.set('sources')
-            from sourceSets.main.allSource
-        }
-
-        task javadocJar(type: Jar) {
-            archiveClassifier.set('javadoc')
-            from javadoc
-        }
-
-        artifacts {
-            archives sourcesJar
-            archives javadocJar
-        }
 
         publications {
             mavenJava(MavenPublication) {
@@ -52,9 +69,6 @@ allprojects {
 
                 // Custom pom
                 pom {
-                    packaging = packagingType
-                    groupId = group
-                    artifactId = artifact
 
                     name = libraryName
                     description = libraryDescription
@@ -80,7 +94,7 @@ allprojects {
                     scm {
                         connection = gitUrl
                         developerConnection = gitUrl
-                        url = siteUrl
+                        url = gitHttpsUrl
                     }
                 }
             }

--- a/publish.gradle
+++ b/publish.gradle
@@ -2,7 +2,7 @@
  * Maven publishing configuration
  * */
 
-// Maven basis attributes
+// Maven pom.xml attributes
 ext {
     libraryName = 'Testerra TeamCity Connector'
     artifact = project.getName().toLowerCase()
@@ -11,57 +11,20 @@ ext {
     libraryDescription = "Testerra ${project.getName()} module"
 
     siteUrl = 'https://testerra.io'
-    gitUrl = 'https://github.com/telekom/testerra-teamcity-connector.git'
+    gitUrl = 'scm:git:git://github.com/telekom/testerra-teamcity-connector.git'
     issueUrl = 'https://github.com/telekom/testerra-teamcity-connector/issues'
 
     developerId = 'MMS'
     developerName = 'Testerra Team T-Systems MMS'
     developerEmail = 'testerra@t-systems-mms.com'
+    developerOrganization = 'T-Systems MMS'
+    developerOrganizationUrl = 'https://www.t-systems-mms.com/'
 
     licenseName = 'The Apache Software License, Version 2.0'
     licenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
     allLicenses = ["Apache-2.0"]
 }
 
-// Set up the Maven publication.
-install {
-    repositories.mavenInstaller {
-        // This generates POM.xml with proper parameters
-        pom.project {
-            packaging packagingType
-            groupId group
-            artifactId artifact
-
-            // Add your description here
-            name libraryName
-            description libraryDescription
-            url siteUrl
-
-            // Set your license
-            licenses {
-                license {
-                    name licenseName
-                    url licenseUrl
-                }
-            }
-            developers {
-                developer {
-                    id developerId
-                    name developerName
-                    email developerEmail
-                }
-            }
-            scm {
-                connection gitUrl
-                developerConnection gitUrl
-                url siteUrl
-            }
-
-        }
-    }
-}
-
-// Publish to a Maven repository
 allprojects {
 
     publishing {
@@ -86,6 +49,40 @@ allprojects {
                 from components.java
                 artifact javadocJar
                 artifact sourcesJar
+
+                // Custom pom
+                pom {
+                    packaging = packagingType
+                    groupId = group
+                    artifactId = artifact
+
+                    name = libraryName
+                    description = libraryDescription
+                    url = siteUrl
+
+                    licenses {
+                        license {
+                            name = licenseName
+                            url = licenseUrl
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            id = developerId
+                            name = developerName
+                            email = developerEmail
+                            organization = developerOrganization
+                            organizationUrl = developerOrganizationUrl
+                        }
+                    }
+
+                    scm {
+                        connection = gitUrl
+                        developerConnection = gitUrl
+                        url = siteUrl
+                    }
+                }
             }
         }
 
@@ -109,7 +106,7 @@ allprojects {
                     beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
                 }
             }
-        }
 
+        }
     }
 }

--- a/publish.gradle
+++ b/publish.gradle
@@ -4,99 +4,112 @@
 
 // Maven basis attributes
 ext {
-  libraryName = 'Testerra TeamCity Connector'
-  artifact = project.getName().toLowerCase()
-  packagingType = 'jar'
+    libraryName = 'Testerra TeamCity Connector'
+    artifact = project.getName().toLowerCase()
+    packagingType = 'jar'
 
-  libraryDescription = "Testerra ${project.getName()} module"
+    libraryDescription = "Testerra ${project.getName()} module"
 
-  siteUrl = 'https://testerra.io'
-  gitUrl = 'https://github.com/telekom/testerra-teamcity-connector.git'
-  issueUrl = 'https://github.com/telekom/testerra-teamcity-connector/issues'
+    siteUrl = 'https://testerra.io'
+    gitUrl = 'https://github.com/telekom/testerra-teamcity-connector.git'
+    issueUrl = 'https://github.com/telekom/testerra-teamcity-connector/issues'
 
-  developerId = 'MMS'
-  developerName = 'Testerra Team T-Systems MMS'
-  developerEmail = 'testerra@t-systems-mms.com'
+    developerId = 'MMS'
+    developerName = 'Testerra Team T-Systems MMS'
+    developerEmail = 'testerra@t-systems-mms.com'
 
-  licenseName = 'The Apache Software License, Version 2.0'
-  licenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-  allLicenses = ["Apache-2.0"]
+    licenseName = 'The Apache Software License, Version 2.0'
+    licenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+    allLicenses = ["Apache-2.0"]
 }
 
 // Set up the Maven publication.
 install {
-  repositories.mavenInstaller {
-    // This generates POM.xml with proper parameters
-    pom.project {
-      packaging packagingType
-      groupId group
-      artifactId artifact
+    repositories.mavenInstaller {
+        // This generates POM.xml with proper parameters
+        pom.project {
+            packaging packagingType
+            groupId group
+            artifactId artifact
 
-      // Add your description here
-      name libraryName
-      description libraryDescription
-      url siteUrl
+            // Add your description here
+            name libraryName
+            description libraryDescription
+            url siteUrl
 
-      // Set your license
-      licenses {
-        license {
-          name licenseName
-          url licenseUrl
+            // Set your license
+            licenses {
+                license {
+                    name licenseName
+                    url licenseUrl
+                }
+            }
+            developers {
+                developer {
+                    id developerId
+                    name developerName
+                    email developerEmail
+                }
+            }
+            scm {
+                connection gitUrl
+                developerConnection gitUrl
+                url siteUrl
+            }
+
         }
-      }
-      developers {
-        developer {
-          id developerId
-          name developerName
-          email developerEmail
-        }
-      }
-      scm {
-        connection gitUrl
-        developerConnection gitUrl
-        url siteUrl
-      }
-
     }
-  }
 }
 
 // Publish to a Maven repository
 allprojects {
 
-  publishing {
+    publishing {
 
-    task sourcesJar(type: Jar, dependsOn: classes) {
-      archiveClassifier.set('sources')
-      from sourceSets.main.allSource
-    }
-
-    task javadocJar(type: Jar) {
-      archiveClassifier.set('javadoc')
-      from javadoc
-    }
-
-    artifacts {
-      archives sourcesJar
-      archives javadocJar
-    }
-
-    publications {
-      mavenJava(MavenPublication) {
-        from components.java
-        artifact javadocJar
-        artifact sourcesJar
-      }
-    }
-
-    repositories {
-      maven {
-        url System.getProperty("deployUrl", "none")
-        credentials {
-          username System.getProperty("deployUsername", "none")
-          password System.getProperty("deployPassword", "none")
+        task sourcesJar(type: Jar, dependsOn: classes) {
+            archiveClassifier.set('sources')
+            from sourceSets.main.allSource
         }
-      }
+
+        task javadocJar(type: Jar) {
+            archiveClassifier.set('javadoc')
+            from javadoc
+        }
+
+        artifacts {
+            archives sourcesJar
+            archives javadocJar
+        }
+
+        publications {
+            mavenJava(MavenPublication) {
+                from components.java
+                artifact javadocJar
+                artifact sourcesJar
+            }
+        }
+
+        repositories {
+            maven {
+                url System.getProperty("deployUrl", "none")
+                credentials {
+                    username System.getProperty("deployUsername", "none")
+                    password System.getProperty("deployPassword", "none")
+                }
+            }
+        }
+
+        signing {
+            sign publishing.publications.mavenJava
+        }
+
+        uploadArchives {
+            repositories {
+                mavenDeployer {
+                    beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+                }
+            }
+        }
+
     }
-  }
 }


### PR DESCRIPTION
# Important note

From this date all future deployments are published under the groupId io.testerra. 

# Description

Please delete options that are not relevant.

- Changed groupid to `io.testerra` based of MavenCentral requirements
- Changed and fixed publishing tasks
- Added support for MavenCentral (Sonatype Nexus) to close and release the packages
- Added signing of all JAR files
- Added Javadoc generating
- Updated documentation